### PR TITLE
refactor: 다음 우편번호 서비스 추가 #27

### DIFF
--- a/app/(anon)/test/post-code/page.module.css
+++ b/app/(anon)/test/post-code/page.module.css
@@ -1,0 +1,200 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.title {
+  text-align: center;
+  color: #333;
+  margin-bottom: 2rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.formContainer {
+  background: #f8f9fa;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+}
+
+.inputGroup {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  padding: 12px 16px;
+  border: 2px solid #e1e5e9;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 0.3s ease;
+  background: white;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.input:read-only {
+  background-color: #f8f9fa;
+  color: #6c757d;
+}
+
+.searchButton {
+  padding: 12px 24px;
+  background: linear-gradient(135deg, #007bff, #0056b3);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.searchButton:hover {
+  background: linear-gradient(135deg, #0056b3, #004085);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+.searchButton:active {
+  transform: translateY(0);
+}
+
+.codeContainer {
+  background: #e8f4fd;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border-left: 4px solid #007bff;
+  margin-bottom: 2rem;
+}
+
+.codeTitle {
+  margin: 0 0 1rem 0;
+  color: #007bff;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.codeGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.codeItem {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.codeLabel {
+  font-weight: 600;
+  color: #495057;
+  min-width: 100px;
+}
+
+.codeValue {
+  color: #007bff;
+  font-family: 'Courier New', monospace;
+  font-weight: 600;
+  background: #f8f9fa;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #dee2e6;
+}
+
+.postcodeContainer {
+  background: white;
+  border: 2px solid #007bff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  margin-top: 2rem;
+}
+
+.postcodeHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: linear-gradient(135deg, #007bff, #0056b3);
+  color: white;
+}
+
+.postcodeHeader h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.3s ease;
+}
+
+.closeButton:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.postcodeFrame {
+  width: 100%;
+  height: 500px;
+  border: none;
+  background: #f8f9fa;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+  
+  .inputGroup {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  
+  .searchButton {
+    width: 100%;
+  }
+  
+  .postcodeFrame {
+    height: 400px;
+  }
+  
+  .codeItem {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  
+  .codeLabel {
+    min-width: auto;
+  }
+} 

--- a/app/(anon)/test/post-code/page.tsx
+++ b/app/(anon)/test/post-code/page.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import styles from './page.module.css';
+
+interface DaumPostcodeData {
+  zonecode: string;
+  address: string;
+  roadAddress: string;
+  jibunAddress: string;
+  userSelectedType: 'R' | 'J';
+  bname: string;
+  buildingName: string;
+  apartment: string;
+  sigunguCode: string;
+  bcode: string;
+}
+
+interface DaumPostcodeSize {
+  height: number;
+  width: number;
+}
+
+interface DaumPostcode {
+  new (options: {
+    oncomplete: (data: DaumPostcodeData) => void;
+    onresize: (size: DaumPostcodeSize) => void;
+    width: string;
+    height: string;
+  }): {
+    embed: (element: HTMLDivElement | null) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    daum: {
+      Postcode: DaumPostcode;
+    };
+  }
+}
+
+export default function PostCodePage() {
+  const [postcode, setPostcode] = useState('');
+  const [address, setAddress] = useState('');
+  const [detailAddress, setDetailAddress] = useState('');
+  const [extraAddress, setExtraAddress] = useState('');
+  const [sigunguCode, setSigunguCode] = useState('');
+  const [bcode, setBcode] = useState('');
+  const [showPostcode, setShowPostcode] = useState(false);
+  
+  const postcodeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Daum Postcode 스크립트 로드
+    const script = document.createElement('script');
+    script.src = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.async = true;
+    document.head.appendChild(script);
+
+    return () => {
+      if (document.head.contains(script)) {
+        document.head.removeChild(script);
+      }
+    };
+  }, []);
+
+  const execDaumPostcode = () => {
+    if (!window.daum) {
+      alert('Daum Postcode 스크립트가 로드되지 않았습니다.');
+      return;
+    }
+
+    setShowPostcode(true);
+    
+    // 약간의 지연을 두어 DOM이 업데이트된 후 실행
+    setTimeout(() => {
+      if (postcodeRef.current) {
+        new window.daum.Postcode({
+          oncomplete: function(data: DaumPostcodeData) {
+            let addr = '';
+            let extraAddr = '';
+
+            if (data.userSelectedType === 'R') {
+              addr = data.roadAddress;
+            } else {
+              addr = data.jibunAddress;
+            }
+
+            if (data.userSelectedType === 'R') {
+              if (data.bname !== '' && /[동|로|가]$/g.test(data.bname)) {
+                extraAddr += data.bname;
+              }
+              if (data.buildingName !== '' && data.apartment === 'Y') {
+                extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+              }
+              if (extraAddr !== '') {
+                extraAddr = ' (' + extraAddr + ')';
+              }
+              setExtraAddress(extraAddr);
+            } else {
+              setExtraAddress('');
+            }
+
+            setPostcode(data.zonecode);
+            setAddress(addr);
+            setSigunguCode(data.sigunguCode || '');
+            setBcode(data.bcode || '');
+            setShowPostcode(false);
+          },
+          onresize: function(size: DaumPostcodeSize) {
+            if (postcodeRef.current) {
+              postcodeRef.current.style.height = size.height + 'px';
+            }
+          },
+          width: '100%',
+          height: '100%'
+        }).embed(postcodeRef.current);
+      }
+    }, 100);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Daum 우편번호 검색</h1>
+      
+      <div className={styles.formContainer}>
+        <div className={styles.inputGroup}>
+          <input
+            type='text'
+            id='sample3_postcode'
+            placeholder='우편번호'
+            value={postcode}
+            readOnly
+            className={styles.input}
+          />
+          <button
+            type='button'
+            onClick={execDaumPostcode}
+            className={styles.searchButton}
+          >
+            우편번호 찾기
+          </button>
+        </div>
+        
+        <input
+          type='text'
+          id='sample3_address'
+          placeholder='주소'
+          value={address}
+          readOnly
+          className={styles.input}
+        />
+        
+        <input
+          type='text'
+          id='sample3_detailAddress'
+          placeholder='상세주소'
+          value={detailAddress}
+          onChange={(e) => setDetailAddress(e.target.value)}
+          className={styles.input}
+        />
+        
+        <input
+          type='text'
+          id='sample3_extraAddress'
+          placeholder='참고항목'
+          value={extraAddress}
+          readOnly
+          className={styles.input}
+        />
+      </div>
+
+      {showPostcode && (
+        <div className={styles.postcodeContainer}>
+          <div className={styles.postcodeHeader}>
+            <h3>우편번호 검색</h3>
+            <button
+              onClick={() => setShowPostcode(false)}
+              className={styles.closeButton}
+            >
+              ✕
+            </button>
+          </div>
+          <div
+            ref={postcodeRef}
+            className={styles.postcodeFrame}
+          />
+        </div>
+      )}
+
+      <div className={styles.codeContainer}>
+        <h3 className={styles.codeTitle}>추가 정보</h3>
+        <div className={styles.codeGroup}>
+          <div className={styles.codeItem}>
+            <span className={styles.codeLabel}>시군구코드:</span>
+            <span className={styles.codeValue}>{sigunguCode || '없음'}</span>
+          </div>
+          <div className={styles.codeItem}>
+            <span className={styles.codeLabel}>법정동코드:</span>
+            <span className={styles.codeValue}>{bcode || '없음'}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "15.4.4",
         "node-rsa": "^1.1.1",
         "react": "19.1.0",
+        "react-daum-postcode": "^3.2.0",
         "react-dom": "19.1.0"
       },
       "devDependencies": {
@@ -4487,6 +4488,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.2.0.tgz",
+      "integrity": "sha512-NHY8TUicZXMqykbKYT8kUo2PEU7xu1DFsdRmyWJrLEUY93Xhd3rEdoJ7vFqrvs+Grl9wIm9Byxh3bI+eZxepMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "15.4.4",
     "node-rsa": "^1.1.1",
     "react": "19.1.0",
+    "react-daum-postcode": "^3.2.0",
     "react-dom": "19.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 📌 Issue
- 관련 이슈: #27 

---

## 🛠 작업 내용
<img width="886" height="672" alt="image" src="https://github.com/user-attachments/assets/b4f57bf8-770e-474a-b878-899e929fd4f1" />
- `npm install react-daum-postcode` 했습니다
- 결과로 시군구 코드, 법정동코드까지 표출하는 test페이지 작성했습니다.
- ***

## 🚀 기타 사항
- 다음 우편번호 서비스 가이드 문서 : https://postcode.map.daum.net/guide#sample
- 참고한 블로그 문서 : https://velog.io/@endmoseung/%EB%A6%AC%EC%95%A1%ED%8A%B8%EB%8B%A4%EC%9D%8C-%EC%A3%BC%EC%86%8C-API-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0

closes #27 
