### PR TITLE
feat: #75 step_result updated_at 사용

### DIFF
--- a/backend/domain/entities/StepResult.ts
+++ b/backend/domain/entities/StepResult.ts
@@ -8,6 +8,7 @@ export class StepResult {
     public unchecked?: number | null,
     public details?: unknown,
     public createdAt?: Date,
+    public updatedAt?: Date,
     public mainNum?: number,
     public subNum?: number
   ) {}

--- a/backend/infrastructure/repository/StepResultRepositoryImpl.ts
+++ b/backend/infrastructure/repository/StepResultRepositoryImpl.ts
@@ -36,7 +36,7 @@ export class StepResultRepositoryImpl implements StepResultRepository {
       return stepResults.map((result) => new StepResult(
         result.id, result.userAddressId, result.stepId,
         result.mismatch, result.match, result.unchecked,
-        result.details, result.createdAt,
+        result.details, result.createdAt, result.updatedAt,
         result.step?.mainNum, result.step?.subNum
       ));
     } catch (error) {
@@ -74,12 +74,13 @@ export class StepResultRepositoryImpl implements StepResultRepository {
         unchecked: number | null;
         details: unknown;
         createdAt: Date;
+        updatedAt: Date;
         step?: { mainNum: number; subNum: number };
       };
       return new StepResult(
         result.id, result.userAddressId, result.stepId,
         result.mismatch, result.match, result.unchecked,
-        result.details, result.createdAt,
+        result.details, result.createdAt, result.updatedAt,
         result.step?.mainNum, result.step?.subNum
       );
     } catch (error) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,7 @@ model StepResult {
   unchecked     Int?
   details       Json        @map("details")
   createdAt     DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt     DateTime    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   step          Step        @relation(fields: [stepId], references: [id], onDelete: Cascade)
   userAddress   UserAddress @relation(fields: [userAddressId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #75 

---

## 🛠 작업 내용

- 마이페이지에서 사용자에게 결과 화면에서 최종 수정 일자를 알려주기 위해 updated_at을 추가했습니다.
- 이것이 추가됨으로써 사용자는 어떤 주소를 선택했을 때, 언제 검사가 갱신됐는지 확인할 수 있습니다.


- ***

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- <img width="797" height="135" alt="image" src="https://github.com/user-attachments/assets/02cbf6b3-71bd-4747-b24a-af92d32834f4" />
- 여기서 사용됩니다.
- 빌드 오류 : danJi에서 발생하고 있는 것입니다.
- 이번에 스키마 업데이트 할 때 튜플 초기화 안됐습니다. 만세!