### PR TITLE
feat: 라디오 버튼 그룹 및 라디오 버튼 컴포넌트 추가

### DIFF
--- a/app/(anon)/_components/common/radioButtonGroup/RadioButton.styles.ts
+++ b/app/(anon)/_components/common/radioButtonGroup/RadioButton.styles.ts
@@ -1,0 +1,24 @@
+export const styles = {
+  // 라디오 버튼 컨테이너
+  radioContainer: "flex items-center justify-center cursor-pointer",
+  
+  // 라디오 버튼 입력
+  radioInput: "sr-only",
+  
+  // 라디오 버튼 커스텀 디자인
+  radioButton: "w-5 h-5 rounded-full border-2 transition-all duration-200",
+  
+  // 라디오 버튼 상태별 스타일
+  unchecked: "border-brand-light-gray bg-brand-white",
+  checked: "border-brand bg-brand",
+  
+  // 체크 표시
+  checkmark: "w-2 h-2 rounded-full bg-brand-white mx-auto mt-1",
+  
+  // 라벨 텍스트 (숨김)
+  radioLabel: "sr-only",
+  
+  // 비활성화 상태
+  disabled: "opacity-50 cursor-not-allowed",
+  disabledLabel: "text-brand-light-gray"
+} as const;

--- a/app/(anon)/_components/common/radioButtonGroup/RadioButton.tsx
+++ b/app/(anon)/_components/common/radioButtonGroup/RadioButton.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { forwardRef } from 'react';
+import clsx from 'clsx';
+import { styles } from './RadioButton.styles';
+
+type RadioButtonProps = {
+  id: string;
+  name: string;
+  value: string;
+  label: string;
+  checked: boolean;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
+  ({ id, name, value, label, checked, onChange, disabled = false, className }, ref) => {
+    const handleChange = () => {
+      if (!disabled) {
+        onChange(value);
+      }
+    };
+
+    return (
+      <div 
+        className={clsx(
+          styles.radioContainer,
+          disabled && styles.disabled,
+          className
+        )}
+        onClick={handleChange}
+      >
+        <input
+          ref={ref}
+          type="radio"
+          id={id}
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={handleChange}
+          disabled={disabled}
+          className={styles.radioInput}
+        />
+        
+        <div className={clsx(
+          styles.radioButton,
+          checked ? styles.checked : styles.unchecked
+        )}>
+          {checked && <div className={styles.checkmark} />}
+        </div>
+        
+        <label 
+          htmlFor={id}
+          className={clsx(
+            styles.radioLabel,
+            disabled && styles.disabledLabel
+          )}
+        >
+          {label}
+        </label>
+      </div>
+    );
+  }
+);
+
+RadioButton.displayName = 'RadioButton';
+
+export default RadioButton;

--- a/app/(anon)/_components/common/radioButtonGroup/RadioButtonGroup.styles.ts
+++ b/app/(anon)/_components/common/radioButtonGroup/RadioButtonGroup.styles.ts
@@ -1,0 +1,11 @@
+export const styles = {
+  // 그룹 컨테이너
+  group: "space-y-4",
+  
+  // 라벨 영역
+  labelContainer: "flex items-center justify-center space-x-4 mb-3",
+  label: "text-sm font-medium text-brand-dark-gray",
+  
+  // 라디오 버튼 행
+  row: "flex items-center justify-center space-x-6"
+} as const;

--- a/app/(anon)/_components/common/radioButtonGroup/RadioButtonGroup.tsx
+++ b/app/(anon)/_components/common/radioButtonGroup/RadioButtonGroup.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { styles } from './RadioButtonGroup.styles';
+import RadioButton from './RadioButton';
+
+type RadioOption = {
+  value: string;
+  label: string;
+};
+
+type RadioButtonGroupProps = {
+  name: string;
+  options: RadioOption[];
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+  showYesNoLabels?: boolean;
+};
+
+const RadioButtonGroup = ({
+  name,
+  options,
+  defaultValue,
+  onChange,
+  disabled = false,
+  className,
+  showYesNoLabels = true
+}: RadioButtonGroupProps) => {
+  const [selectedValue, setSelectedValue] = useState(defaultValue || options[0]?.value || '');
+
+  const handleChange = (value: string) => {
+    setSelectedValue(value);
+    onChange?.(value);
+  };
+
+  // 옵션을 2개씩 그룹화
+  const groupedOptions = [];
+  for (let i = 0; i < options.length; i += 2) {
+    groupedOptions.push(options.slice(i, i + 2));
+  }
+
+  return (
+    <div className={clsx(styles.group, className)}>
+      {showYesNoLabels && (
+        <div className={styles.labelContainer}>
+          <span className={styles.label}>아니오</span>
+          <span className={styles.label}>예</span>
+        </div>
+      )}
+      
+      {groupedOptions.map((row, rowIndex) => (
+        <div key={rowIndex} className={styles.row}>
+          {row.map((option) => (
+            <RadioButton
+              key={option.value}
+              id={`${name}-${option.value}`}
+              name={name}
+              value={option.value}
+              label={option.label}
+              checked={selectedValue === option.value}
+              onChange={handleChange}
+              disabled={disabled}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RadioButtonGroup;

--- a/app/(anon)/test/radio-button-group-test/page.tsx
+++ b/app/(anon)/test/radio-button-group-test/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import RadioButtonGroup from '@/(anon)/_components/common/radioButtonGroup/RadioButtonGroup';
+
+const RadioButtonGroupTest = () => {
+  const [selectedValue1, setSelectedValue1] = useState('');
+  const [selectedValue2, setSelectedValue2] = useState('');
+
+  const options1 = [
+    { value: 'no', label: '아니오' },
+    { value: 'yes', label: '예' }
+  ];
+
+  const options2 = [
+    { value: 'option1', label: '옵션 1' },
+    { value: 'option2', label: '옵션 2' },
+    { value: 'option3', label: '옵션 3' },
+    { value: 'option4', label: '옵션 4' }
+  ];
+
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-2xl font-bold mb-6 text-brand-dark-gray">
+        라디오 버튼 그룹 테스트
+      </h1>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4 text-brand-dark-gray">
+          기본 라디오 버튼 그룹 (예/아니오)
+        </h3>
+        <RadioButtonGroup
+          name="example1"
+          options={options1}
+          onChange={setSelectedValue1}
+        />
+        <p className="mt-2 text-sm text-brand-dark-gray">
+          선택된 값: {selectedValue1 || '없음'}
+        </p>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4 text-brand-dark-gray">
+          여러 옵션 라디오 버튼 그룹
+        </h3>
+        <RadioButtonGroup
+          name="example2"
+          options={options2}
+          onChange={setSelectedValue2}
+        />
+        <p className="mt-2 text-sm text-brand-dark-gray">
+          선택된 값: {selectedValue2 || '없음'}
+        </p>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4 text-brand-dark-gray">
+          라벨 없이 표시
+        </h3>
+        <RadioButtonGroup
+          name="example4"
+          options={options1}
+          showYesNoLabels={false}
+        />
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4 text-brand-dark-gray">
+          여러 행의 독립적인 라디오 버튼 그룹 (2개씩 같은 그룹)
+        </h3>
+        <div className="space-y-4">
+          {/* 첫 번째 행 - 첫 번째 그룹 */}
+          <RadioButtonGroup
+            name="group1"
+            options={[
+              { value: 'yes1', label: '예' },
+              { value: 'no1', label: '아니오' }
+            ]}
+            showYesNoLabels={false}
+          />
+          
+          {/* 두 번째 행 - 두 번째 그룹 */}
+          <RadioButtonGroup
+            name="group2"
+            options={[
+              { value: 'yes2', label: '예' },
+              { value: 'no2', label: '아니오' }
+            ]}
+            showYesNoLabels={false}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4 text-brand-dark-gray">
+          비활성화된 라디오 버튼 그룹
+        </h3>
+        <RadioButtonGroup
+          name="example3"
+          options={options1}
+          disabled={true}
+          defaultValue="yes"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default RadioButtonGroupTest;


### PR DESCRIPTION

## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #173 

---

## 🛠 작업 내용
<img width="522" height="770" alt="image" src="https://github.com/user-attachments/assets/5006af3a-58f5-4685-90a2-0eb9f1ce1270" />

- 라디오 버튼 그룹과 라디오 버튼 컴포넌트를 새로 구현하여 선택 기능을 추가했습니다.
- 각 컴포넌트에 대한 스타일을 정의하고, 기본적인 라디오 버튼 그룹 테스트 페이지를 추가했습니다.
- 라디오 버튼 그룹은 여러 옵션을 그룹화하여 표시하며, 비활성화 상태 및 라벨 표시 여부를 설정할 수 있습니다.
- 테스트 페이지 : http://localhost:3000/test/radio-button-group-test

- ***

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)
- 테스트 페이지는 그냥 인라인 스타일 사용했습니다.

- [x] build 체크 했나요? 넹 -> eslint 에러가 나오지만 이것은 @layout-SY 님이 담당해주신다고 합니다

- [x] dev를 pull 받은 뒤 merge 했나요? 최신 브랜치 분기라서 안 해도 됨