### PR TITLE
feat : 용어 설명을 위한 infoToolTop 컴포넌트 작성

### DIFF
--- a/app/(anon)/_components/common/infoToolTip/InfoToolTip.styles.ts
+++ b/app/(anon)/_components/common/infoToolTip/InfoToolTip.styles.ts
@@ -1,0 +1,10 @@
+export const styles = {
+  tooltipContainer: 'relative inline-block',
+  highlightedText: 'text-base text-brand-green font-bold underline cursor-pointer relative',
+  tooltip: 'fixed bg-brand-light-blue border border-brand-light-gray rounded-lg p-3 shadow-lg z-50 min-w-[12.5rem] max-w-[18.75rem]',
+  tooltipVisible: 'opacity-100 visible',
+  tooltipHidden: 'opacity-0 invisible pointer-events-none',
+  tooltipArrow: 'absolute -top-1.5 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3 border-r-3 border-b-3 border-transparent border-b-brand-light-blue',
+  tooltipArrowBorder: 'absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3.5 border-r-3.5 border-b-3.5 border-transparent border-b-brand-light-gray -z-10',
+  tooltipText: 'text-brand-black text-sm leading-relaxed text-center'
+};

--- a/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
+++ b/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
@@ -6,13 +6,11 @@ import { styles } from './InfoToolTip.styles';
 interface InfoToolTipProps {
   term: string;
   definition: string | string[];
-  children?: React.ReactNode;
 }
 
 export default function InfoToolTip({
   term,
   definition,
-  children,
 }: InfoToolTipProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState({
@@ -211,8 +209,6 @@ export default function InfoToolTip({
           </div>
         )}
       </span>
-
-      {children}
     </div>
   );
 }

--- a/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
+++ b/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { styles } from './InfoToolTip.styles';
+
+interface InfoToolTipProps {
+  term: string;
+  definition: string | string[];
+  children?: React.ReactNode;
+}
+
+export default function InfoToolTip({
+  term,
+  definition,
+  children,
+}: InfoToolTipProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState({
+    top: 0,
+    left: 0,
+    arrowDirection: 'bottom',
+  });
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+          !containerRef.current.contains(event.target as Node) &&
+          tooltipRef.current &&
+          !tooltipRef.current.contains(event.target as Node)
+      ) {
+        setIsVisible(false);
+      }
+    };
+
+    const handleScroll = () => {
+      if (isVisible) {
+        // 스크롤 시 즉시 위치 업데이트 (애니메이션 없음)
+        calculateTooltipPosition();
+      }
+    };
+
+    const handleResize = () => {
+      if (isVisible) {
+        calculateTooltipPosition();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleResize, { passive: true });
+    
+    // 모바일 환경을 위한 추가 이벤트
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', handleResize);
+      window.visualViewport.addEventListener('scroll', handleScroll);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+      
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', handleResize);
+        window.visualViewport.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, [isVisible]);
+
+  const calculateTooltipPosition = () => {
+    if (!containerRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    
+    // 모바일 환경을 위한 정확한 뷰포트 크기 계산
+    const viewportHeight = Math.min(window.innerHeight, window.visualViewport?.height || window.innerHeight);
+    const viewportWidth = Math.min(window.innerWidth, window.visualViewport?.width || window.innerWidth);
+    
+    // 툴팁의 예상 높이를 계산 (텍스트 길이 기반)
+    const definitionText = Array.isArray(definition)
+      ? definition.join(' ')
+      : definition;
+    const estimatedTooltipHeight =
+      Math.ceil(definitionText.length / 50) * 1.5 + 2.5;
+    const estimatedTooltipWidth = Math.min(
+      Math.max(12.5, definitionText.length * 0.5),
+      Math.min(18.75, viewportWidth / 16 - 1.25)
+    );
+
+    let top = 0;
+    let left = 0;
+    let arrowDirection = 'bottom';
+
+    // 툴팁 높이를 픽셀로 변환
+    const tooltipHeightPx = estimatedTooltipHeight * 16;
+    
+    // 단순하게: 위아래 공간 중 더 넓은 쪽에 툴팁 배치
+    const spaceBelow = viewportHeight - containerRect.bottom;
+    const spaceAbove = containerRect.top;
+    const gap = 3; // 글씨와 툴팁 사이 간격
+    const textHeight = 16; // 글씨 높이 (16px)
+    
+    // 디버깅 정보 출력
+    console.log('Tooltip positioning debug:', {
+      containerRect: {
+        top: containerRect.top,
+        bottom: containerRect.bottom,
+        left: containerRect.left,
+        width: containerRect.width
+      },
+      viewport: { height: viewportHeight, width: viewportWidth },
+      tooltip: { height: tooltipHeightPx, width: estimatedTooltipWidth * 16 },
+      spaces: { below: spaceBelow, above: spaceAbove },
+      gap,
+      textHeight
+    });
+    
+    // 기본적으로 아래쪽에 배치 시도
+    if (spaceBelow >= tooltipHeightPx + gap) {
+      // 아래쪽에 충분한 공간이 있으면 아래에 배치
+      top = containerRect.bottom + gap;
+      arrowDirection = 'bottom';
+      console.log('Placing tooltip below text');
+    } else if (spaceAbove >= tooltipHeightPx + gap + textHeight) {
+      // 위쪽에 충분한 공간이 있으면 위에 배치 (글씨 높이만큼 추가 간격)
+      top = containerRect.top - tooltipHeightPx - gap - textHeight*4.5;
+      arrowDirection = 'top';
+      console.log('Placing tooltip above text');
+    } else {
+      // 위아래 모두 공간이 부족하면 아래에 배치 (스크롤 가능)
+      top = containerRect.bottom + gap;
+      arrowDirection = 'bottom';
+      console.log('Placing tooltip below text (forced)');
+    }
+
+    // 가로 위치 계산 (중앙 정렬)
+    const tooltipWidthPx = estimatedTooltipWidth * 16;
+    left = Math.max(
+      15,
+      Math.min(
+        containerRect.left +
+          containerRect.width / 2 -
+          tooltipWidthPx / 2,
+        viewportWidth - tooltipWidthPx - 15
+      )
+    );
+
+    console.log('Final tooltip position:', { top, left, arrowDirection });
+    setTooltipPosition({ top, left, arrowDirection });
+  };
+
+  const handleTermClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!isVisible) {
+      // 먼저 위치를 계산하고 툴팁을 표시
+      calculateTooltipPosition();
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  const renderDefinition = () => {
+    if (Array.isArray(definition)) {
+      return definition.map((line, index) => (
+        <div
+          key={index}
+          className={index < definition.length - 1 ? 'mb-1' : ''}
+        >
+          {line}
+        </div>
+      ));
+    }
+    return definition;
+  };
+
+  const getArrowClasses = () => {
+    if (tooltipPosition.arrowDirection === 'top') {
+      return 'absolute bottom-0 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3 border-r-3 border-t-3 border-transparent border-t-brand-light-blue';
+    }
+    return 'absolute -top-1.5 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3 border-r-3 border-b-3 border-transparent border-b-brand-light-blue';
+  };
+
+  const getArrowBorderClasses = () => {
+    if (tooltipPosition.arrowDirection === 'top') {
+      return 'absolute bottom-0 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3.5 border-r-3.5 border-t-3.5 border-transparent border-t-brand-light-gray -z-10';
+    }
+    return 'absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-3.5 border-r-3.5 border-b-3.5 border-transparent border-b-brand-light-gray -z-10';
+  };
+
+  return (
+    <div className={styles.tooltipContainer} ref={containerRef}>
+      <span className={styles.highlightedText} onClick={handleTermClick}>
+        {term}
+        {/* 툴팁이 표시될 때만 DOM에 추가 */}
+        {isVisible && (
+          <div
+            ref={tooltipRef}
+            className={`${styles.tooltip} ${styles.tooltipVisible}`}
+            style={{
+              top: `${tooltipPosition.top}px`,
+              left: `${tooltipPosition.left}px`,
+            }}
+          >
+            <div className={getArrowClasses()}></div>
+            <div className={getArrowBorderClasses()}></div>
+            <div className={styles.tooltipText}>{renderDefinition()}</div>
+          </div>
+        )}
+      </span>
+
+      {children}
+    </div>
+  );
+}

--- a/app/(anon)/test/info-tooltip-test/page.tsx
+++ b/app/(anon)/test/info-tooltip-test/page.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import InfoToolTip from '@/(anon)/_components/common/infoToolTip/InfoToolTip';
+
+export default function InfoToolTipTestPage() {
+  return (
+    <div className="p-8 font-sans max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-8 text-center">InfoToolTip 컴포넌트 테스트</h1>
+      
+      <div className="space-y-8">
+        {/* 기본 사용법 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">기본 사용법</h2>
+          <div className="text-lg">
+            사업자상호 : <InfoToolTip 
+              term="신흥사부동산중개인사"
+              definition="사업자가 사업 활동을 위해 사용하는 명칭"
+            />
+          </div>
+        </section>
+
+        {/* 여러 줄 설명 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">여러 줄 설명</h2>
+          <div className="text-lg">
+            중개수수료 : <InfoToolTip 
+              term="중개수수료"
+              definition={[
+                "부동산 중개업자가 중개 서비스를 제공한 대가로 받는 수수료",
+                "일반적으로 거래금액의 0.1~0.9% 범위에서 협의 결정",
+                "법정 상한선이 있음"
+              ]}
+            />
+          </div>
+        </section>
+
+        {/* 부동산 관련 용어들 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">부동산 관련 용어</h2>
+          <div className="space-y-3 text-lg">
+            <div>
+              <InfoToolTip 
+                term="부동산중개업"
+                definition="부동산의 거래, 임대차, 교환을 중개하는 업무"
+              /> : 부동산 거래를 중개하는 업무
+            </div>
+            <div>
+              <InfoToolTip 
+                term="전세권"
+                definition="건물이나 토지를 사용하고 수익할 수 있는 권리"
+              /> : 건물 사용권
+            </div>
+            <div>
+              <InfoToolTip 
+                term="임대차"
+                definition={[
+                  "건물이나 토지를 빌려서 사용하는 계약",
+                  "월세, 전세 등이 포함됨"
+                ]}
+              /> : 임대 계약
+            </div>
+          </div>
+        </section>
+
+        {/* 긴 텍스트와 함께 사용 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">긴 텍스트와 함께 사용</h2>
+          <p className="text-lg leading-relaxed">
+            부동산 거래 시에는 <InfoToolTip 
+              term="중개업소"
+              definition="부동산 중개업을 영위하는 업소"
+            />를 통해 거래하는 것이 일반적입니다. 
+            특히 <InfoToolTip 
+              term="아파트"
+              definition="공동주택의 한 형태로, 여러 가구가 한 건물에 거주하는 주택"
+            />나 <InfoToolTip 
+              term="빌라"
+              definition="소규모 다세대 주택으로, 보통 3-5층 정도의 건물"
+            />와 같은 공동주택의 경우 중개업소를 통한 거래가 필수적입니다.
+          </p>
+        </section>
+
+        {/* 경계 테스트 - 화면 끝에서 툴팁이 잘리지 않는지 확인 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">경계 테스트 (화면 끝에서 잘리지 않음)</h2>
+          <div className="flex justify-between items-start space-x-4">
+            <div className="text-lg">
+              왼쪽 끝: <InfoToolTip 
+                term="왼쪽용어"
+                definition="화면 왼쪽 끝에서 툴팁이 잘리지 않는지 테스트"
+              />
+            </div>
+            <div className="text-lg">
+              오른쪽 끝: <InfoToolTip 
+                term="오른쪽용어"
+                definition="화면 오른쪽 끝에서 툴팁이 잘리지 않는지 테스트"
+              />
+            </div>
+          </div>
+          
+          <div className="mt-4 text-center">
+            <div className="text-lg">
+              중앙: <InfoToolTip 
+                term="중앙용어"
+                definition="화면 중앙에서 툴팁이 제대로 표시되는지 테스트"
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* 스타일 테스트 */}
+        <section className="border border-gray-200 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">스타일 테스트</h2>
+          <div className="space-y-2">
+            <div className="text-sm">
+              작은 글씨: <InfoToolTip 
+                term="소형"
+                definition="크기가 작은 것"
+              />
+            </div>
+            <div className="text-2xl">
+              큰 글씨: <InfoToolTip 
+                term="대형"
+                definition="크기가 큰 것"
+              />
+            </div>
+            <div className="text-blue-600">
+              파란색: <InfoToolTip 
+                term="색상"
+                definition="빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성"
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div className="mt-8 p-4 bg-gray-100 rounded-lg">
+        <h3 className="font-semibold mb-2">사용법:</h3>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>하이라이트된 용어를 클릭하면 툴팁이 나타납니다</li>
+          <li>툴팁 영역 밖을 클릭하면 자동으로 닫힙니다</li>
+          <li>단일 설명과 여러 줄 설명 모두 지원합니다</li>
+          <li>용어는 초록색, 볼드, 밑줄로 표시됩니다</li>
+          <li>화면 <InfoToolTip 
+                term="색상"
+                definition="빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성빛의 파장에 따라 달라지는 시각적 특성"
+              /> 툴팁이 잘리지 않도록 자동으로 위치가 조정됩니다</li>
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- 어려운 용어들을 설명하기 위한 infoToolTop 컴포넌트 작성
- window 상에서 단어의 위치에 따라 infoToolTop의 위치가 상, 하로 위치

## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #174 

---

## 🛠 작업 내용
- 사용자가 하이라이트된 용어를 클릭하면 해당 용어에 대한 정의가 담긴 툴팁이 표시된다.
- 글씨 아래/위 공간을 자동으로 계산하여 최적 위치 선택
- 툴팁이 열린 상태에서 스크롤 시 글씨와 함께 이동

<img width="402" height="505" alt="스크린샷 2025-08-20 오후 12 23 54" src="https://github.com/user-attachments/assets/5091e6fe-74b6-466f-aef9-5075cf577cf4" />

####사용 방법


```tsx
<InfoToolTip 
  term="신흥사부동산중개인사"
  definition="사업자가 사업 활동을 위해 사용하는 명칭"
/>

// 여러 줄 설명
<InfoToolTip 
  term="중개수수료"
  definition={[
    "부동산 중개업자가 중개 서비스를 제공한 대가로 받는 수수료",
    "일반적으로 거래금액의 0.1~0.9% 범위에서 협의 결정",
    "법정 상한선이 있음"
  ]}
/>
```
- ***

## 🚀 기타 사항


- [x] build 체크 했나요?

- [x] dev를 pull 받은 뒤 merge 했나요?