### PR TITLE
fix : 로그아웃 버튼 오작동

### DIFF
--- a/app/(anon)/_components/dashboard/HambugiDashboard.tsx
+++ b/app/(anon)/_components/dashboard/HambugiDashboard.tsx
@@ -141,27 +141,47 @@ export default function HambugiDashboard({ onClose }: HambugiDashboardProps) {
     router.push('/mypage');
   };
 
-  const handleLogout = () => {
-    // 1. 클라이언트 상태 초기화
-    clearUser();
-    clearUserAddressStore();
+  const handleLogout = async () => {
+    console.log('로그아웃버튼 클릭');
+    
+    try {
+      // 1. 클라이언트 상태 초기화
+      console.log('handleLogout - 클라이언트 상태 초기화 시작');
+      clearUser();
+      clearUserAddressStore();
 
-    // 2. sessionStorage 정리 (step 제외)
-    sessionStorage.removeItem('user-store');
-    sessionStorage.removeItem('user-address-store');
+      // 2. sessionStorage 정리 (step 제외)
+      console.log('handleLogout - sessionStorage 정리');
+      sessionStorage.removeItem('user-store');
+      sessionStorage.removeItem('user-address-store');
 
-    // 3. step을 auth로 설정하고 sessionStorage에 저장
-    setStep('auth');
-    sessionStorage.setItem('step', 'auth');
+      // 3. step을 auth로 설정하고 sessionStorage에 저장
+      console.log('handleLogout - step을 auth로 설정');
+      setStep('auth');
+      sessionStorage.setItem('step', 'auth');
+      console.log('handleLogout - sessionStorage step 확인:', sessionStorage.getItem('step'));
 
-    // 4. NextAuth 로그아웃
-    signOut({
-      redirect: false,
-      callbackUrl: '/',
-    });
+      // 4. NextAuth 로그아웃
+      console.log('handleLogout - NextAuth signOut 시작');
+      await signOut({
+        redirect: false,
+        callbackUrl: '/',
+      });
+      console.log('handleLogout - NextAuth signOut 완료');
 
-    // 5. 홈페이지로 리디렉트
-    router.push('/');
+      // 5. 대시보드 닫기
+      console.log('handleLogout - 대시보드 닫기');
+      onClose();
+      
+      // 6. 홈페이지로 강제 리디렉트 (브라우저 새로고침)
+      console.log('handleLogout - 홈페이지로 리디렉트');
+      window.location.href = '/';
+    } catch (error) {
+      console.error('로그아웃 중 오류 발생:', error);
+      // 오류가 발생해도 홈페이지로 이동
+      onClose();
+      window.location.href = '/';
+    }
   };
 
   const handleActionClick = (actionLink: string) => {

--- a/app/(anon)/_components/dashboard/StepNavigation.tsx
+++ b/app/(anon)/_components/dashboard/StepNavigation.tsx
@@ -19,32 +19,10 @@ interface StepNavigationProps {
 export default function StepNavigation({ 
   steps, 
   onStepClick, 
+  onLogout,
   currentStep
 }: StepNavigationProps) {
   const router = useRouter();
-  
-  const handleLogout = async () => {
-    try {
-      // TODO: 실제 로그아웃 API 호출
-      // const response = await fetch('/api/auth/logout', {
-      //   method: 'POST',
-      //   credentials: 'include'
-      // });
-      
-      // if (response.ok) {
-      //   // 로그아웃 성공 처리
-      //   console.log('로그아웃 성공');
-      // }
-      
-      // 로그아웃 처리 후 홈페이지로 이동
-      console.log('로그아웃 처리 후 홈페이지로 이동');
-      router.push('/');
-    } catch (error) {
-      console.error('로그아웃 중 오류 발생:', error);
-      // 오류가 발생해도 홈페이지로 이동
-      router.push('/');
-    }
-  };
   return (
     <div className={styles.container}>
       {/* 단계 목록 */}
@@ -65,9 +43,8 @@ export default function StepNavigation({
         })}
       </div>
       
-      {/* 로그아웃 버튼 */}
       <button
-        onClick={handleLogout}
+        onClick={onLogout}
         className={styles.logoutButton}
       >
         로그아웃

--- a/app/(anon)/steps/[step-number]/page.tsx
+++ b/app/(anon)/steps/[step-number]/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-export default Steps3Page;
-
 import {
   useEffect,
   useRef,
@@ -41,7 +39,7 @@ interface StepData {
   pages: PageData[];
 }
 
-export function Steps3Page() {
+export default function Steps3Page() {
   const router = useRouter();
   const bookRef = useRef<{ pageFlip?: { flip: (page: number) => void } }>(null);
   const [marginLeft, setMarginLeft] = useState('-73%');

--- a/libs/stores/rootStepStore.ts
+++ b/libs/stores/rootStepStore.ts
@@ -16,7 +16,7 @@ export const useRootStep = create<RootStepStore>((set) => ({
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('step', step);
     }
-    set({ step });
+    set({ step, initialized: true });
   },
   initStepFromSession: () => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #195 

---

## 🛠 작업 내용
 ### 원인
 - `StepNavigation` 컴포넌트에서 `handleLogout` 함수 중복 선언 
 
 - 제거 및 `onLogout` prop 활용
 - StepNavigation 컴포넌트에서 중복 handleLogout 함수 제거 및 onLogout prop 활용
- HambugiDashboard에서 로그아웃 시 step을 'auth'로 설정하도록 수정
- useRootStep 스토어의 setStep에서 initialized도 함께 설정하도록 개선
- 로그아웃 후 RootFlow가 정상적으로 AuthLanding 컴포넌트를 렌더링하도록 수정
- 로그아웃 후 window.location.href를 사용하여 브라우저 새로고침으로 완전한 상태 초기화

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] build 체크 했나요?

- [x] dev를 pull 받은 뒤 merge 했나요?