### PR TITLE
feat: Header 컴포넌트의 상위 페이지 이동 로직 개선 및 페이지 스타일 수정, 중단계 리팩토링

### DIFF
--- a/app/(anon)/@detail/steps/[step-number]/[detail]/_components/ModalContent.tsx
+++ b/app/(anon)/@detail/steps/[step-number]/[detail]/_components/ModalContent.tsx
@@ -52,12 +52,12 @@ export default function ModalContent() {
       case 'TextOnly':
         return <TextOnly data={pageData} />;
       case 'Table':
-        return <Table data={pageData as unknown as Record<string, string>} />;
+        return <Table data={pageData as unknown as { left: string; right?: string }[]} />;
       case 'List':
-        return <List data={pageData as unknown as Record<string, string>} />;
+        return <List data={pageData as unknown as { left: string; right?: string }[]} />;
       case 'DataGrid':
         return (
-          <DataGrid data={pageData as unknown as Record<string, string>} />
+          <DataGrid data={pageData as unknown as { left: string; right?: string }[]} />
         );
       case 'RadioGroup':
         return <RadioGroup data={pageData} />;
@@ -150,7 +150,7 @@ export default function ModalContent() {
 
       {/* 기본 DataGrid 표시 */}
       <div className={styles.mainContent}>
-        <DataGrid data={{}} />
+        <DataGrid data={[]} />
       </div>
     </>
   );

--- a/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/DataGrid.tsx
+++ b/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/DataGrid.tsx
@@ -2,19 +2,19 @@ import styles from './DataGrid.styles';
 import CircularIconBadge from '@/(anon)/_components/common/circularIconBadges/CircularIconBadge';
 
 interface DataGridProps {
-  data: Record<string, string>;
+  data: { left: string; right?: string }[];
 }
 
 const DataGrid = ({ data }: DataGridProps) => {
   return (
     <div>
-      {Object.entries(data).map(([key, value], index) => (
+      {data.map((item, index) => (
         <div key={index} className={styles.detailItem}>
           <div className={styles.detailKey}>
-            {key}:
+            {item.left}:
           </div>
           <div className={styles.detailValue}>
-            <CircularIconBadge type={value as 'match' | 'mismatch' | 'unchecked'} size="xsm" />
+            <CircularIconBadge type={item.right as 'match' | 'mismatch' | 'unchecked'} size="xsm" />
           </div>
         </div>
       ))}

--- a/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/List.tsx
+++ b/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/List.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './List.styles';
 
 interface ListProps {
-  data: Record<string, string>;
+  data: { left: string; right?: string }[];
 }
 
 const List = ({ data }: ListProps) => {

--- a/app/(anon)/_components/common/header/Header.tsx
+++ b/app/(anon)/_components/common/header/Header.tsx
@@ -39,7 +39,17 @@ export default function Header() {
               />
             ) : (
               <button
-                onClick={() => router.back()}
+                onClick={() => {
+                  // 상위 페이지로 이동
+                  const pathSegments = pathname.split('/').filter(Boolean);
+                  if (pathSegments.length > 1) {
+                    // 첫 번째 세그먼트만 유지 (예: steps/4 -> steps)
+                    const parentPath = '/' + pathSegments[0];
+                    router.push(parentPath);
+                  } else {
+                    router.push('/main');
+                  }
+                }}
                 className={styles.backButton}
               >
                 <ChevronLeft />

--- a/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
+++ b/app/(anon)/_components/common/infoToolTip/InfoToolTip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { styles } from './InfoToolTip.styles';
 
 interface InfoToolTipProps {
@@ -21,54 +21,7 @@ export default function InfoToolTip({
   const tooltipRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-          !containerRef.current.contains(event.target as Node) &&
-          tooltipRef.current &&
-          !tooltipRef.current.contains(event.target as Node)
-      ) {
-        setIsVisible(false);
-      }
-    };
-
-    const handleScroll = () => {
-      if (isVisible) {
-        // 스크롤 시 즉시 위치 업데이트 (애니메이션 없음)
-        calculateTooltipPosition();
-      }
-    };
-
-    const handleResize = () => {
-      if (isVisible) {
-        calculateTooltipPosition();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    window.addEventListener('resize', handleResize, { passive: true });
-    
-    // 모바일 환경을 위한 추가 이벤트
-    if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', handleResize);
-      window.visualViewport.addEventListener('scroll', handleScroll);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      window.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('resize', handleResize);
-      
-      if (window.visualViewport) {
-        window.visualViewport.removeEventListener('resize', handleResize);
-        window.visualViewport.removeEventListener('scroll', handleScroll);
-      }
-    };
-  }, [isVisible]);
-
-  const calculateTooltipPosition = () => {
+  const calculateTooltipPosition = useCallback(() => {
     if (!containerRef.current) return;
 
     const containerRect = containerRef.current.getBoundingClientRect();
@@ -148,7 +101,54 @@ export default function InfoToolTip({
 
     console.log('Final tooltip position:', { top, left, arrowDirection });
     setTooltipPosition({ top, left, arrowDirection });
-  };
+  }, [definition]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+          !containerRef.current.contains(event.target as Node) &&
+          tooltipRef.current &&
+          !tooltipRef.current.contains(event.target as Node)
+      ) {
+        setIsVisible(false);
+      }
+    };
+
+    const handleScroll = () => {
+      if (isVisible) {
+        // 스크롤 시 즉시 위치 업데이트 (애니메이션 없음)
+        calculateTooltipPosition();
+      }
+    };
+
+    const handleResize = () => {
+      if (isVisible) {
+        calculateTooltipPosition();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleResize, { passive: true });
+    
+    // 모바일 환경을 위한 추가 이벤트
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', handleResize);
+      window.visualViewport.addEventListener('scroll', handleScroll);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+      
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', handleResize);
+        window.visualViewport.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, [isVisible, calculateTooltipPosition]);
 
   const handleTermClick = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/app/(anon)/_components/common/pdfViewer/PdfViewer.tsx
+++ b/app/(anon)/_components/common/pdfViewer/PdfViewer.tsx
@@ -51,7 +51,7 @@ export function PdfViewer({
       setIsLoading(false);
       setError('PDF 데이터가 없습니다.');
     }
-  }, [base64]);
+  }, [base64, pdfUrl]);
 
   if (isLoading) {
     return (

--- a/app/(anon)/_components/common/stateIcon/StateIcon.styles.ts
+++ b/app/(anon)/_components/common/stateIcon/StateIcon.styles.ts
@@ -1,6 +1,6 @@
 export const styles = {
   // 컨테이너
-  container: 'flex gap-1.5 w-full',
+  container: 'flex gap-1.5 w-full justify-center',
 
   // 상태 아이템 - 고정 크기로 균등 배치
   item: 'flex items-center justify-evenly px-3 py-2 rounded-2xl flex-1 min-w-[6rem] max-w-[6rem]',

--- a/app/(anon)/_components/common/taxCert/TaxCert.tsx
+++ b/app/(anon)/_components/common/taxCert/TaxCert.tsx
@@ -34,7 +34,7 @@ export default function TaxCert() {
 
   // 커스텀 훅들 사용
   const { validateFormData } = useTaxCertValidation();
-  const { isLoading, error, response, setError, submitTaxCert, submitTwoWayAuth } = useTaxCertApi();
+  const { isLoading, error, setError, submitTaxCert, submitTwoWayAuth } = useTaxCertApi();
   const { showSimpleAuthModal, setShowSimpleAuthModal, handleFirstRequestComplete } = useTaxCertTwoWay();
   
   const { handleInputChange, handleLoginTypeLevelChange, handleSubmit, handleSimpleAuthApprove, handleSimpleAuthCancel } = useTaxCertHandlers(

--- a/app/(anon)/_components/common/taxCert/TaxCertResultDisplay.tsx
+++ b/app/(anon)/_components/common/taxCert/TaxCertResultDisplay.tsx
@@ -57,7 +57,7 @@ export default function TaxCertResultDisplay() {
             try {
               // 이미 복호화된 JSON 객체이므로 파싱 불필요
               setData(result.data.taxCertJson);
-            } catch (parseError) {
+            } catch {
               setError('납세증명서 데이터 형식이 올바르지 않습니다.');
             }
           } else if (result.data.data && result.data.data.taxCertJson) {
@@ -69,7 +69,7 @@ export default function TaxCertResultDisplay() {
                 // data 필드가 없으면 전체 taxCertJson 사용
                 setData(result.data.data.taxCertJson);
               }
-            } catch (parseError) {
+            } catch {
               setError('납세증명서 데이터 형식이 올바르지 않습니다.');
             }
           } else if (result.data.taxCertData) {
@@ -77,7 +77,7 @@ export default function TaxCertResultDisplay() {
             try {
               const taxCertData = JSON.parse(result.data.taxCertData);
               setData(taxCertData);
-            } catch (parseError) {
+            } catch {
               setError('납세증명서 데이터 형식이 올바르지 않습니다.');
             }
           } else {
@@ -86,7 +86,7 @@ export default function TaxCertResultDisplay() {
         } else {
           setError(result.message || '납세증명서 데이터를 조회할 수 없습니다.');
         }
-      } catch (err) {
+      } catch {
         setError('납세증명서 데이터 조회 중 오류가 발생했습니다.');
       } finally {
         setLoading(false);

--- a/app/(anon)/steps/[step-number]/_components/GeneralPage.styles.ts
+++ b/app/(anon)/steps/[step-number]/_components/GeneralPage.styles.ts
@@ -1,10 +1,34 @@
-export const GeneralPageStyles = {
-  generalWhitePage: 'bg-brand-white w-full h-full flex items-start justify-start box-border relative',
+export const styles = {
+  // 일반 흰색 페이지 기본 스타일
+  contents: 'bg-brand-white w-full h-full flex flex-col box-border relative shadow-xl',
+  
+  // 상단 영역
+  topSection: 'flex-none text-center p-6 border-b border-b-brand-light-gray',
+  
+  // 중간 영역
+  middleSection: 'flex-1 p-6',
+  
+  // 하단 영역
+  bottomSection: 'flex-none flex justify-end p-6 border-t border-t-brand-light-gray',
+  
+  // 작은 폰트 영역 스타일
   smallFontDiv: 'relative pb-[2vh] pt-[2vh] border-b border-b-brand-light-gray w-full',
+  
+  // 하단 경계선 영역 스타일
   borderBottomDiv: 'border-b border-b-brand-light-gray py-[4vh] px-[10%] h-[38vh] max-h-[38vh] overflow-y-auto',
-  danger: 'text-[0.8em] font-bold w-[22%] shadow-[inset_0px_-11px_0_rgba(194,74,74,0.3)]',
+  
+  // 위험 표시 스타일
+  danger: 'text-[0.8em] font-bold w-[16%] shadow-[inset_0px_-11px_0_rgba(194,74,74,0.3)]',
+  
+  // 콘텐츠 텍스트 스타일
   content: 'text-[0.8em] mt-[4vh] leading-[2.5vh]',
+  
+  // 이동 버튼 내부 스타일
   goInside: 'flex items-center',
+  
+  // 이동 버튼 컨테이너 스타일
   goInsideDiv: 'flex items-center flex-1 w-full h-[13%] absolute bottom-0 left-[75%]',
-  smallFont: 'font-bold text-[0.8em] flex items-center justify-center pt-[0.3vh]',
-}
+  
+  // 작은 폰트 스타일
+  smallFont: 'font-bold text-[0.8em] flex items-center justify-center pt-[0.3vh]'
+} as const;

--- a/app/(anon)/steps/[step-number]/_components/GeneralPage.tsx
+++ b/app/(anon)/steps/[step-number]/_components/GeneralPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GeneralPageStyles } from './GeneralPage.styles';
+import { styles } from './GeneralPage.styles';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -10,6 +10,7 @@ interface pageType {
   content: string;
   pageIdx: number;
   stepNumber: string;
+  currentPage: number;
 }
 
 export default function GeneralPage({
@@ -18,6 +19,7 @@ export default function GeneralPage({
   content,
   pageIdx,
   stepNumber,
+  currentPage,
 }: pageType) {
   const router = useRouter();
   const [, setStepNum] = useState<string>('');
@@ -27,6 +29,8 @@ export default function GeneralPage({
 
     const newUrl = `/steps/${stepNumber}/${pageIdx}`;
 
+    // 현재 보고 있는 페이지 정보를 sessionStorage에 저장 (뒤로가기 시 복원용)
+    sessionStorage.setItem('saved-page', currentPage.toString());
     sessionStorage.setItem('programmatic-navigation', 'true');
     sessionStorage.setItem('navigation-timestamp', Date.now().toString());
     window.dispatchEvent(new PopStateEvent('popstate'));
@@ -35,26 +39,29 @@ export default function GeneralPage({
   };
 
   return (
-    <div className={GeneralPageStyles.generalWhitePage}>
-      <div>
-        <div className={GeneralPageStyles.smallFontDiv}>
-          <h3 className={GeneralPageStyles.smallFont}> {title} </h3>
-        </div>
-        <div className={GeneralPageStyles.borderBottomDiv}>
-          <h5 className={GeneralPageStyles.danger}> {category} </h5>
-          <p
-            className={GeneralPageStyles.content}
-            style={{ whiteSpace: 'pre-line' }}
-          >
-            {content}
-          </p>
-        </div>
-        <div className={GeneralPageStyles.goInsideDiv}>
-          <button className={GeneralPageStyles.goInside} onClick={handleClick}>
-            {' '}
-            바로가기{' '}
-          </button>
-        </div>
+    <div className={styles.contents}>
+      {/* 상단 */}
+      <div className={styles.topSection}>
+        <h3 className={styles.smallFont}> {title} </h3>
+      </div>
+      
+      {/* 중간 */}
+      <div className={styles.middleSection}>
+        <h5 className={styles.danger}> {category} </h5>
+        <p
+          className={styles.content}
+          style={{ whiteSpace: 'pre-line' }}
+        >
+          {content}
+        </p>
+      </div>
+      
+      {/* 하단 */}
+      <div className={styles.bottomSection}>
+        <button className={styles.goInside} onClick={handleClick}>
+          {' '}
+          바로가기{' '}
+        </button>
       </div>
     </div>
   );

--- a/app/(anon)/steps/[step-number]/_components/SummaryPage.styles.ts
+++ b/app/(anon)/steps/[step-number]/_components/SummaryPage.styles.ts
@@ -1,14 +1,46 @@
-export const SummaryPageStyles = {
-  generalPage: 'bg-brand w-full h-full flex items-start justify-start box-border relative',
-  leftDiv: 'w-[50px] h-full flex flex-col bg-transparent border-none shadow-none flex-shrink-0',
-  leftFirst: "flex-1 w-full h-[20%] bg-transparent border-r-[10px] border-r-brand-light-gray border-b-[3px] border-b-brand-light-gray",
-  leftCenter: "flex-1 w-full h-[20%] bg-transparent border-t-[10px] border-t-brand-light-gray border-r-[10px] border-r-brand-light-gray border-b-[3px] border-b-brand-light-gray",
-  leftLast: "flex-1 w-full h-[20%] bg-transparent border-t-[10px] border-t-brand-light-gray border-r-[10px] border-r-brand-light-gray",
-  rightFirstOutsideBox: 'w-[87%] bg-white h-[5vh] rounded-lg ml-[6%] mt-[2vh]',
-  rightFirstInsideBox: 'w-[95%] border-2 border-brand mx-auto mt-[2vh] rounded-lg h-[3.5vh] relative top-[0.6vh]',
+export const styles = {
+  // 전체 북커버 컨테이너 (기존 모양 유지)
+  bookCover: 'bg-brand w-full h-full flex items-start justify-start box-border relative',
+  
+  // 왼쪽 영역 컨테이너 스타일
+  leftDiv: 'w-[3.4rem] h-full flex flex-col bg-transparent border-none shadow-none flex-shrink-0',
+  
+  // 왼쪽 첫 번째 박스 스타일 (상단)
+  leftFirst: "flex-1 border-r-[0.6rem] border-b-[0.3rem] border-brand-light-gray",
+  
+  // 왼쪽 중앙 박스 스타일 (중간)
+  leftCenter: "flex-1 border-t-[0.3rem] border-r-[0.6rem] border-b-[0.3rem] border-brand-light-gray",
+  
+  // 왼쪽 마지막 박스 스타일 (하단)
+  leftLast: "flex-1 border-t-[0.3rem] border-r-[0.6rem] border-brand-light-gray",
+  
+  // 오른쪽 영역 컨테이너 스타일
+  rightContainer: 'h-full w-full flex flex-col relative',
+  
+  // 오른쪽 첫 번째 외부 박스 스타일 (제목 영역)
+  rightFirstOutsideBox: 'w-[calc(100%-2rem)] bg-white h-16 rounded-lg mt-4 mx-4 p-2 relative',
+  
+  // 오른쪽 첫 번째 내부 박스 스타일 (제목 테두리)
+  rightFirstInsideBox: 'relative w-full h-full border-2 border-brand rounded-lg flex items-center justify-center',
+  
+  // 작은 폰트 스타일 (제목 텍스트)
   smallFont: 'font-bold text-[0.8em] flex items-center justify-center pt-[0.3vh]',
-  whitePaper: 'w-[90%] bg-white ml-[5%] rounded-xl mt-[2vh] p-[2vh_4%] h-[60vh] min-h-[40vh]',
-  topic: 'text-[0.8em] font-bold pb-[1vh] pt-[1vh] border-b border-gray-400 mb-[1.5vh]',
-  introContent: 'text-[0.65em] pb-[1vh]',
-  generalPageGreen: 'bg-brand-dark-green w-full h-full flex items-start justify-start box-border relative'
+  
+  // 흰색 종이 스타일 (메인 콘텐츠 영역) - flex로 상-하 분할
+  whitePaper: 'w-[calc(100%-2rem)] bg-white rounded-lg m-4 flex-1 overflow-y-auto',
+  
+  // 흰색 종이 상단 영역 (제목)
+  whitePaperTop: 'flex-none pb-4 border-b border-b-brand-light-gray',
+  
+  // 흰색 종이 하단 영역 (내용)
+  whitePaperBottom: 'flex-1 pt-4 overflow-y-auto',
+  
+  // 주제 제목 스타일 (섹션 제목)
+  topic: 'text-sm font-bold p-4 border-b border-brand-light-gray',
+  
+  // 소개 콘텐츠 스타일 (본문 텍스트)
+  introContent: 'text-xs px-4 pt-2 leading-relaxed',
+  
+  // 북커버 다크 그린 스타일 (후기 단계용)
+  bookCoverGreen: 'bg-brand-dark-green w-full h-full flex items-start justify-start box-border relative'
 } as const;

--- a/app/(anon)/steps/[step-number]/_components/SummaryPage.tsx
+++ b/app/(anon)/steps/[step-number]/_components/SummaryPage.tsx
@@ -1,4 +1,4 @@
-import { SummaryPageStyles } from './SummaryPage.styles';
+import { styles } from './SummaryPage.styles';
 
 interface SummaryPageProps {
   title: string;
@@ -8,30 +8,33 @@ interface SummaryPageProps {
 
 export default function SummaryPage({ title, contents, stepNumber }: SummaryPageProps) {
   const isEarlyStep = ['1', '2', '3'].includes(stepNumber);
-  const generalPageClass = isEarlyStep
-    ? SummaryPageStyles.generalPage
-    : SummaryPageStyles.generalPageGreen;
+  const bookCoverClass = isEarlyStep
+    ? styles.bookCover
+    : styles.bookCoverGreen;
   return (
-    <div className={generalPageClass}>
-      <div className={SummaryPageStyles.leftDiv}>
-        <div className={SummaryPageStyles.leftFirst}></div>
-        <div className={SummaryPageStyles.leftCenter}></div>
-        <div className={SummaryPageStyles.leftCenter}></div>
-        <div className={SummaryPageStyles.leftCenter}></div>
-        <div className={SummaryPageStyles.leftLast}></div>
+    <div className={bookCoverClass}>
+      <div className={styles.leftDiv}>
+        <div className={styles.leftFirst}></div>
+        <div className={styles.leftCenter}></div>
+        <div className={styles.leftCenter}></div>
+        <div className={styles.leftCenter}></div>
+        <div className={styles.leftLast}></div>
       </div>
-      <div>
-        <div className={SummaryPageStyles.rightFirstOutsideBox}>
-          <div className={SummaryPageStyles.rightFirstInsideBox}>
-            <p className={SummaryPageStyles.smallFont}> {title} </p>
+      <div className={styles.rightContainer}>
+        {/* 상단 영역 */}
+        <div className={styles.rightFirstOutsideBox}>
+          <div className={styles.rightFirstInsideBox}>
+            <p className={styles.smallFont}> {title} </p>
           </div>
         </div>
-        <div className={SummaryPageStyles.whitePaper + ' max-h-[340px] overflow-y-auto'}>
+        
+        {/* 하단 영역 */}
+        <div className={styles.whitePaper}>
           {contents.map((block, i) => (
             <div key={i}>
-              <h6 className={SummaryPageStyles.topic}>{block.subtitle}</h6>
+              <h6 className={styles.topic}>{block.subtitle}</h6>
               {block.items.map((item, j) => (
-                <p key={j} className={SummaryPageStyles.introContent}>{item}</p>
+                <p key={j} className={styles.introContent}>{item}</p>
               ))}
             </div>
           ))}

--- a/app/(anon)/steps/[step-number]/page.styles.ts
+++ b/app/(anon)/steps/[step-number]/page.styles.ts
@@ -1,54 +1,46 @@
 export const styles = {
-  container: "p-5 h-screen bg-brand-light-gray",
-  content: "text-center py-10 px-5",
-  title: "text-2xl font-semibold text-brand-black mb-8",
-  clickButton: "bg-brand text-brand-white border-none py-3 px-6 rounded-lg text-base font-medium cursor-pointer transition-colors hover:bg-brand-dark-blue active:bg-brand-black",
-
-  demoBook: 'mx-auto shadow-[10px_10px_15px_-5px_rgba(0,0,0,0.4)]',
-  page: 'bg-brand-white shadow-[0_10px_15px_-3px_rgba(0,0,0,0.1),0_4px_6px_-2px_rgba(0,0,0,0.05)] rounded-[8px] overflow-hidden relative',
-  pageCover: 'bg-brand-light-blue font-bold flex items-center justify-center',
+  // 플립북 데모 스타일
+  demoBook: 'mx-auto',
+  
+  // 페이지 기본 스타일
+  page: 'bg-brand-white shadow-xl rounded-[8px] overflow-hidden relative',
+  
+  // 페이지 콘텐츠 영역 스타일
   pageContent: 'p-8 min-h-[600px] flex flex-col justify-center items-center',
-  pageHeader: 'text-[1.5rem] mb-4',
-  pageFooter: 'mt-8 text-[1rem] text-brand-dark-gray',
-  leftClickArea: 'absolute left-0 top-0 w-[30%] h-full z-[10] cursor-pointer', 
-  indicatorWrapper: 'w-[180px] mt-8 flex items-center justify-between relative',
+  
+  // 플렉스 컨테이너 스타일
+  flex: 'flex h-full shadow-xl',
+  
+  // 인디케이터 래퍼 스타일
+  indicatorWrapper: 'w-[180px] flex items-center justify-between relative',
+  
+  // 인디케이터 왼쪽 영역 스타일
   indicatorLeft: 'absolute left-0 top-0 h-full flex items-center',
+  
+  // 인디케이터 오른쪽 영역 스타일
   indicatorRight: 'absolute right-0 top-0 h-full flex items-center',
+  
+  // 인디케이터 점들 컨테이너 스타일
   indicatorDots: 'flex justify-center items-center w-full',
+  
+  // 인디케이터 화살표 버튼 스타일
   indicatorArrowBtn: 'bg-none border-none p-0 cursor-pointer h-6 flex items-center',
-  indicatorDotBtn: 'mx-[6px]',
-  book: 'max-w-[480px] w-full h-full mx-auto bg-[rgba(229,231,235,0.3)] relative overflow-hidden min-h-[calc(100vh-4rem)] box-border flex flex-col justify-center items-center border-0',
-  flipBook: 'flex items-center justify-center w-fit h-fit overflow-visible relative border-none',
-  flex: 'flex h-full',
-  introPage: 'bg-white mx-auto w-full h-[300px] flex items-center justify-center box-border',
-  underlineBold: 'bg-brand-error',
-  upPoint: 'w-0 h-0 border-l-[15px] border-l-brand-error border-r-[15px] border-r-brand-error border-t-[15px] border-t-transparent border-b-[15px] border-b-brand-error ml-1/2',
-  pageNum: 'bg-brand rounded-full w-[30px] h-[30px] text-white border-none flex items-center justify-center font-bold cursor-pointer m-2 pl-2',
-  pageNumDiv: 'absolute left-[calc(100%-20px)] top-[20%] flex flex-col gap-3',
-  boldMainText: 'font-bold text-[0.9em] mt-[3vh] ml-[2.5%]',
-  numCircle: 'w-[6%] h-[6%] bg-black text-white flex items-center justify-center text-[0.8em] rounded-full',
-  circleAndText: 'flex mt-[3vh] ml-[2.5%]',
-  smallText: 'text-[0.75em] ml-[5%]',
-  generalPage: 'bg-brand w-full h-full flex items-start justify-start box-border relative',
-  generalPageTitle: 'text-white font-bold mt-[3vh] ml-[5%]',
-  insideBox: 'w-[90%] h-[80%] bg-white mt-[2.5vh] ml-0',
-  blue: 'absolute w-[95%] h-[4%] bg-brand rounded-[30em] bottom-[2%] z-[1]',
-  dangerDiv: 'absolute w-[45%] border border-black pt-[0.5vh] pb-[0.5vh] rounded-2xl ml-[23%] flex mt-[3vh]',
-  text: 'w-[95%] h-[50%] pt-[25%] pl-[5%] text-center text-[0.85em]',
-  goDiv: 'absolute bottom-[6.3vh] left-[65%]',
-  go: 'font-bold',
-  goToLink: 'flex justify-center pt-[10vh] underline',
-  goToNext: 'absolute w-[30%] h-[3vh] bg-white z-[5] bottom-[1.3vh] ml-[65%]',
-  left: 'w-[15%] h-full flex flex-col bg-transparent border-none shadow-none',
-  firstLeftBox: 'flex-1 w-full h-[20%] bg-transparent border-r-[10px] border-r-brand-light-gray border-b-[3px] border-b-brand-light-gray',
-  leftBox: 'flex-1 w-full h-[20%] bg-transparent border-t-[10px] border-t-brand-light-gray border-r-[10px] border-r-brand-light-gray border-b-[3px] border-b-brand-light-gray',
-  lastLeftBox: 'flex-1 w-full h-[20%] bg-transparent border-t-[10px] border-t-brand-light-gray] border-r-[10px] border-r-brand-light-gray',
-  backPage: 'h-screen w-[1.5%] bg-gray-300 border-t border-t-gray-400 border-r border-r-gray-400 border-b border-b-gray-400 rounded-xl',
-  generalWhitePage: 'bg-white w-full h-full flex items-start justify-start box-border relative',
-  smallFontDiv: 'relative pb-[2vh] pt-[2vh] border-b border-b-brand-light-gray w-full',
-  borderBottomDiv: 'border-b border-b-brand-light-gray py-[4vh] px-[10%] h-[38vh] max-h-[38vh] overflow-y-auto',
-  danger: 'text-[0.8em] font-bold w-[22%] shadow-[inset_0px_-11px_0_#EDC9C9]',
-  stateDiv: "absolute top-[13%] left-1/2 -translate-x-1/2 ",
-  dot: 'h-2 w-2 rounded-full transition-all duration-200 ease-in-out bg-brand-light-gray',
-  dotActive: 'h-2 w-2 rounded-full transition-all duration-200 ease-in-out bg-brand-black'
+  
+  // 인디케이터 점 기본 스타일
+  dot: 'h-2 w-2 rounded-full transition-all duration-200 ease-in-out bg-brand-light-gray mx-1.5',
+  
+  // 인디케이터 점 활성화 스타일
+  dotActive: 'h-2 w-2 rounded-full transition-all duration-200 ease-in-out bg-brand-black mx-1.5',
+  
+  // 메인 컨테이너 flex 스타일
+  mainContainer: 'flex flex-col items-center justify-center w-full max-w-[480px] h-[calc(100vh-4rem)] gap-8',
+  
+  // StateIcon 영역 스타일 (15%)
+  stateIconArea: 'w-full h-[15%] flex items-end justify-center',
+  
+  // HTMLFlipBook 영역 스타일 (70%)
+  flipBookArea: 'w-full h-[70%] flex items-center overflow-hidden',
+  
+  // 인디케이터 영역 스타일 (15%)
+  indicatorArea: 'w-full h-[15%] flex items-start justify-center'
 } as const;

--- a/app/(anon)/steps/[step-number]/page.styles.ts
+++ b/app/(anon)/steps/[step-number]/page.styles.ts
@@ -1,5 +1,5 @@
 export const styles = {
-  container: "p-5 min-h-screen bg-brand-light-gray",
+  container: "p-5 h-screen bg-brand-light-gray",
   content: "text-center py-10 px-5",
   title: "text-2xl font-semibold text-brand-black mb-8",
   clickButton: "bg-brand text-brand-white border-none py-3 px-6 rounded-lg text-base font-medium cursor-pointer transition-colors hover:bg-brand-dark-blue active:bg-brand-black",
@@ -17,7 +17,7 @@ export const styles = {
   indicatorDots: 'flex justify-center items-center w-full',
   indicatorArrowBtn: 'bg-none border-none p-0 cursor-pointer h-6 flex items-center',
   indicatorDotBtn: 'mx-[6px]',
-  book: 'max-w-[480px] w-full mx-auto bg-[rgba(229,231,235,0.3)] relative overflow-hidden min-h-screen box-border flex flex-col justify-center items-center border-0',
+  book: 'max-w-[480px] w-full h-full mx-auto bg-[rgba(229,231,235,0.3)] relative overflow-hidden min-h-[calc(100vh-4rem)] box-border flex flex-col justify-center items-center border-0',
   flipBook: 'flex items-center justify-center w-fit h-fit overflow-visible relative border-none',
   flex: 'flex h-full',
   introPage: 'bg-white mx-auto w-full h-[300px] flex items-center justify-center box-border',

--- a/app/(anon)/steps/[step-number]/page.tsx
+++ b/app/(anon)/steps/[step-number]/page.tsx
@@ -9,6 +9,7 @@ import SummaryPage from '@/(anon)/steps/[step-number]/_components/SummaryPage';
 import StateIcon from '@/(anon)/_components/common/stateIcon/StateIcon';
 import { useRouter } from 'next/navigation';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ReactNode } from 'react';
 
 interface PageContent {
   subtitle: string;
@@ -32,11 +33,39 @@ type PageData = SummaryPageData | GeneralPageData;
 
 export default function MiddleStepPage() {
   const router = useRouter();
-  const bookRef = useRef<{ pageFlip?: { flip: (page: number) => void } }>(null);
+  const bookRef = useRef<any>(null);
   const [marginLeft, setMarginLeft] = useState('-73%');
   const [currentPage, setCurrentPage] = useState(0);
   const [pages, setPages] = useState<PageData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isManualFlip, setIsManualFlip] = useState(false);
+  const [flipBookInstance, setFlipBookInstance] = useState<any>(null);
+  
+  // 딱 1번만 실행하기 위한 ref
+  const hasInitialized = useRef(false);
+
+  // 컴포넌트 마운트 시 딱 1번만 실행
+  if (!hasInitialized.current && typeof window !== 'undefined') {
+    hasInitialized.current = true;
+    
+    console.log('=== 세션스토리지 값 확인 ===');
+    const savedPage = sessionStorage.getItem('saved-page');
+    
+    console.log('saved-page:', savedPage);
+    
+    // saved-page가 있으면 페이지 복원
+    if (savedPage !== null) {
+      const pageIndex = parseInt(savedPage);
+      if (!isNaN(pageIndex) && pageIndex >= 0) {
+        setCurrentPage(pageIndex);
+      }
+    } else {
+      setCurrentPage(0);
+    }
+ 
+    // 복원 후 플래그 제거
+    sessionStorage.removeItem('saved-page');
+  }
 
   useEffect(() => {
     const match = window.location.pathname.match(/\/steps\/(\d+)/);
@@ -69,7 +98,7 @@ export default function MiddleStepPage() {
       : null;
   const stepNumber = match ? match[1] : '1';
 
-  const flipPages: React.ReactNode[] = [];
+  const flipPages: ReactNode[] = [];
   pages.forEach((page: PageData, idx: number) => {
     if (page.type === 'summary') {
       flipPages.push(
@@ -90,6 +119,7 @@ export default function MiddleStepPage() {
             content={page.content ?? ''}
             pageIdx={idx}
             stepNumber={stepNumber}
+            currentPage={currentPage}
           />
         </div>
       );
@@ -106,61 +136,81 @@ export default function MiddleStepPage() {
   useEffect(() => {
     const width = window.innerWidth;
     if (width <= 400) {
-      setMarginLeft('translateX(-45%)');
+      setMarginLeft('translateX(-48.5%)');
     } else if (width <= 430) {
-      setMarginLeft('translateX(-42%)');
+      setMarginLeft('translateX(-45.5%)');
     } else {
-      setMarginLeft('translateX(-37%)');
+      setMarginLeft('translateX(-40.5%)');
     }
   }, []);
 
   if (loading) return <div>데이터를 불러오는 중...</div>;
-
+  
   return (
-    <div className={styles.book}>
-      <div className={styles.stateDiv}>
+    <div className={styles.mainContainer}>
+      <div className={styles.stateIconArea}>
         <StateIcon completedCount={2} unconfirmedCount={1} warningCount={0} />
       </div>
+      
+      <div className={styles.flipBookArea}>
+        <HTMLFlipBook
+          ref={bookRef}
+          className={styles.demoBook}
+          width={450}
+          height={650}
+          size='stretch'
+          minWidth={350}
+          maxWidth={550}
+          minHeight={450}
+          maxHeight={700}
+          maxShadowOpacity={0.5}
+          showCover={true}
+          mobileScrollSupport={true}
+          startPage={currentPage * 2} // 저장된 페이지 정보를 반영하여 시작 페이지 설정
+          drawShadow={true}
+          flippingTime={1000}
+          usePortrait={false}
+          style={
+            marginLeft.startsWith('translateX')
+              ? { transform: marginLeft }
+              : { marginLeft }
+          }
+          startZIndex={0}
+          autoSize={true}
+          clickEventForward={true}
+          useMouseEvents={true}
+          swipeDistance={30}
+          showPageCorners={false}
+          disableFlipByClick={false}
+          onInit={(flipBook: any) => {
+            // flipBook 객체를 별도로 저장
+            setFlipBookInstance(flipBook);
+            bookRef.current = flipBook;
+          }}
+          onFlip={(e: { data: number }) => {
+            // 수동 페이지 넘김이 아닐 때만 currentPage 업데이트
+            if (!isManualFlip) {
+              // e.data는 flipPages 배열의 인덱스
+              // 실제 콘텐츠 페이지는 0, 2, 4... 위치에 있으므로 2로 나눔
+              const calculatedPage = Math.floor((e.data + 1) / 2);
+              // 계산된 페이지가 유효한 범위 내에 있는지 확인
+              if (calculatedPage >= 0 && calculatedPage < totalPages) {
+                setCurrentPage(calculatedPage);
+              }
+            }
+            // 플래그 리셋 (약간의 지연을 두어 수동 설정이 우선되도록 함)
+            setTimeout(() => {
+              setIsManualFlip(false);
+            }, 50);
+          }}
+        >
+          {flipPages}
+        </HTMLFlipBook>
+      </div>
 
-      <HTMLFlipBook
-        ref={bookRef}
-        className={styles.demoBook}
-        width={550}
-        height={733}
-        size='stretch'
-        minWidth={315}
-        maxWidth={1000}
-        minHeight={400}
-        maxHeight={1533}
-        maxShadowOpacity={0.5}
-        showCover={true}
-        mobileScrollSupport={true}
-        startPage={0}
-        drawShadow={true}
-        flippingTime={1000}
-        usePortrait={false}
-        style={
-          marginLeft.startsWith('translateX')
-            ? { transform: marginLeft, marginTop: 48 }
-            : { marginLeft, marginTop: 48 }
-        }
-        startZIndex={0}
-        autoSize={true}
-        clickEventForward={true}
-        useMouseEvents={true}
-        swipeDistance={30}
-        showPageCorners={false}
-        disableFlipByClick={true}
-        onFlip={(e: { data: number }) => {
-          setCurrentPage(Math.floor((e.data + 1) / 2));
-        }}
-      >
-        {flipPages}
-      </HTMLFlipBook>
-
-      <div className={styles.indicatorWrapper}>
-        <div className={styles.indicatorLeft}>
-          {currentPage === 0 && Number(stepNumber) > 1 && (
+      <div className={styles.indicatorArea}>
+        <div className={styles.indicatorWrapper}>
+          <div className={styles.indicatorLeft}>
             <button
               className={styles.indicatorArrowBtn}
               aria-label='이전 단계로 이동'
@@ -168,28 +218,45 @@ export default function MiddleStepPage() {
             >
               <ChevronLeft size={22} color='#222' />
             </button>
-          )}
-        </div>
-        <div className={styles.indicatorDots}>
-          {Array.from({ length: totalPages }).map((_, j) => (
-            <button
-              key={j}
-              className={`${styles.dot} ${
-                j === currentPage ? styles.dotActive : ''
-              } ${styles.indicatorDotBtn}`}
-              aria-label={`slide ${j + 1}${
-                j === currentPage ? ' (current)' : ''
-              }`}
-              onClick={() => {
-                if (bookRef.current?.pageFlip?.flip) {
-                  bookRef.current.pageFlip.flip(j * 2);
-                }
-              }}
-            />
-          ))}
-        </div>
-        <div className={styles.indicatorRight}>
-          {currentPage === totalPages - 1 && Number(stepNumber) < 7 && (
+          </div>
+          <div className={styles.indicatorDots}>
+            {Array.from({ length: totalPages }).map((_, j) => (
+              <button
+                key={j}
+                className={
+                  j === currentPage ? styles.dotActive : styles.dot
+                 }
+                aria-label={`slide ${j}${
+                  j === currentPage ? ' (current)' : ''
+                }`}
+                onClick={() => {
+                   // flipBookInstance 또는 bookRef.current의 object.flip 함수 사용
+                   const flipBook = flipBookInstance || bookRef.current;
+
+                   if (flipBook?.object?.flip) {
+                     setIsManualFlip(true);
+                     setCurrentPage(j);
+                     
+                     // flipPages 배열에서 실제 콘텐츠 페이지의 인덱스 찾기
+                     // 실제 콘텐츠는 0, 2, 4... 위치에 있고, 빈 페이지는 1, 3, 5... 위치에 있음
+                     const actualPageIndex = j * 2;
+                     
+                     // turnToPage 함수가 있다면 사용 (애니메이션 없음, 더 정확함)
+                     //if (flipBook.object.turnToPage) {
+                       flipBook.object.turnToPage(actualPageIndex);
+                     //} else {
+                     //  flipBook.object.flip(actualPageIndex);
+                     //
+                     // 페이지 이동 후 currentPage를 강제로 설정 (안전장치)
+                     setTimeout(() => {
+                       setCurrentPage(j);
+                     }, 100);
+                   }
+                 }}
+              />
+            ))}
+          </div>
+          <div className={styles.indicatorRight}>
             <button
               className={styles.indicatorArrowBtn}
               aria-label='다음 단계로 이동'
@@ -197,7 +264,7 @@ export default function MiddleStepPage() {
             >
               <ChevronRight size={22} color='#222' />
             </button>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/app/(anon)/steps/[step-number]/page.tsx
+++ b/app/(anon)/steps/[step-number]/page.tsx
@@ -33,13 +33,13 @@ type PageData = SummaryPageData | GeneralPageData;
 
 export default function MiddleStepPage() {
   const router = useRouter();
-  const bookRef = useRef<any>(null);
+  const bookRef = useRef<typeof HTMLFlipBook | null>(null);
   const [marginLeft, setMarginLeft] = useState('-73%');
   const [currentPage, setCurrentPage] = useState(0);
   const [pages, setPages] = useState<PageData[]>([]);
   const [loading, setLoading] = useState(true);
   const [isManualFlip, setIsManualFlip] = useState(false);
-  const [flipBookInstance, setFlipBookInstance] = useState<any>(null);
+  const [flipBookInstance, setFlipBookInstance] = useState<any>(null); // eslint-disable-line @typescript-eslint/no-explicit-any
   
   // 딱 1번만 실행하기 위한 ref
   const hasInitialized = useRef(false);
@@ -182,7 +182,7 @@ export default function MiddleStepPage() {
           swipeDistance={30}
           showPageCorners={false}
           disableFlipByClick={false}
-          onInit={(flipBook: any) => {
+          onInit={(flipBook: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
             // flipBook 객체를 별도로 저장
             setFlipBookInstance(flipBook);
             bookRef.current = flipBook;

--- a/app/(anon)/test/circular-icon-step-test/page.tsx
+++ b/app/(anon)/test/circular-icon-step-test/page.tsx
@@ -89,7 +89,7 @@ export default function CircularIconStepTestPage() {
     };
 
     fetchExistingData();
-  }, [virtualPath, selectedAddress?.id]); // virtualPath나 selectedAddress가 바뀔 때마다 실행
+  }, [virtualPath, selectedAddress, stepInfo]); // virtualPath나 selectedAddress, stepInfo가 바뀔 때마다 실행
 
   const handleStepResultUpdate = (newDetails: Record<string, 'match' | 'mismatch' | 'unchecked'>) => {
     setStepDetails(newDetails);

--- a/app/(anon)/test/post-code/page.tsx
+++ b/app/(anon)/test/post-code/page.tsx
@@ -21,17 +21,6 @@ interface DaumPostcodeSize {
   width: number;
 }
 
-interface DaumPostcode {
-  new (options: {
-    oncomplete: (data: DaumPostcodeData) => void;
-    onresize: (size: DaumPostcodeSize) => void;
-    width: string;
-    height: string;
-  }): {
-    embed: (element: HTMLDivElement | null) => void;
-  };
-}
-
 export default function PostCodePage() {
   const [postcode, setPostcode] = useState('');
   const [address, setAddress] = useState('');


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #229  close #221 close#206

---

## 🛠 작업 내용

- router.back에서 상위페이지로 이동
- 대단계 페이지 스크롤방지
- 중단계 페이지 스타일 리팩토링
- 인디케이터 버튼 오류 수정
- 소단계 > 중단계 이동했을때 페이지 상태 유지
- 
- ***


<img width="441" height="865" alt="image" src="https://github.com/user-attachments/assets/5c307925-56a2-449c-8066-5345de783237" />

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [ ] build 체크 했나요?

- [ ] dev를 pull 받은 뒤 merge 했나요?