### PR TITLE
feat: 체크리스트 및 라디오 그룹 컴포넌트에서 에러 처리 로직 추가

### DIFF
--- a/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/CheckListGroup.styles.ts
+++ b/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/CheckListGroup.styles.ts
@@ -1,6 +1,7 @@
 export const styles = {
   container: 'p-5 max-w-4xl mx-auto space-y-6',
   loadingContainer: 'flex justify-center items-center py-8 text-black',
+  errorContainer: 'flex justify-center items-center py-8 text-brand-error bg-brand-error/10 border border-brand-error rounded-lg',
   section: 'mb-6 space-y-4',
   sectionTitle: 'text-lg font-medium mb-2 text-black',
   descriptionContainer: 'space-y-3 mb-6',

--- a/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/TextOnly.tsx
+++ b/app/(anon)/@detail/steps/[step-number]/[detail]/_components/contents/TextOnly.tsx
@@ -67,19 +67,23 @@ const TextOnly = ({ data }: TextOnlyProps) => {
     detail: stepInfo?.detail?.toString() || ''
   });
 
-  // 에러 시 기본값으로 초기화
+  // json이 {}이거나 에러 시 기본값으로 초기화
   useEffect(() => {
-    if (!isError || data.length === 0 || hasInitialized.current) {
+    if (data.length === 0 || hasInitialized.current) {
       return;
     }
     
-    // 에러 시 바로 POST 요청
-    if (selectedAddress?.id && stepInfo?.stepNumber && stepInfo?.detail) {
+    // jsonDetails가 {}이거나 에러가 발생했을 때 POST 요청
+    const shouldInitialize = (isError && !hasInitialized.current) || 
+                           (stepData?.jsonDetails && Object.keys(stepData.jsonDetails).length === 0);
+    
+    if (shouldInitialize && selectedAddress?.id && stepInfo?.stepNumber && stepInfo?.detail) {
       const defaultDetails: Record<string, 'match'> = {
         '열람': 'match' // TextOnly는 기본적으로 열람 완료 상태
       };
       
-      console.log('🔍 TextOnly: 400 에러 시 기본값 초기화 진행', defaultDetails);
+      const logMessage = isError ? '400 에러 시 기본값 초기화 진행' : '빈 jsonDetails 시 기본값 초기화 진행';
+      console.log(`🔍 TextOnly: ${logMessage}`, defaultDetails);
       
       // DB 저장
       upsertStepResult.mutate({
@@ -94,7 +98,7 @@ const TextOnly = ({ data }: TextOnlyProps) => {
       
       hasInitialized.current = true;
     }
-  }, [isError, data, selectedAddress?.id, selectedAddress?.nickname, stepInfo?.stepNumber, stepInfo?.detail, upsertStepResult, removeQueries]);
+  }, [stepData, isError, data, selectedAddress?.id, selectedAddress?.nickname, stepInfo?.stepNumber, stepInfo?.detail, upsertStepResult, removeQueries]);
 
   // 로딩 상태
   if (isLoading) {
@@ -107,12 +111,12 @@ const TextOnly = ({ data }: TextOnlyProps) => {
       );
   }
 
-  // 에러 상태 (400 에러 시 기본값으로 초기화 진행 중)
+  // 에러 상태 (400 에러 시 데이터를 찾을 수 없다고 표시)
   if (isError && !hasInitialized.current) {
     return (
       <div className={styles.container}>
         <div className={styles.errorContainer}>
-          데이터를 불러오는 중 오류가 발생했습니다. 기본값으로 초기화 중...
+          데이터를 찾을 수 없습니다.
         </div>
       </div>
     );


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #261 

---

## 🛠 작업 내용

- 저장 데이터가 {}가 됨으로써 해당 부분 처리
- db 내 기존 주소 데이터 삭제
- 삭제하면 곤란한 주소(등기부등본 있는 주소)같은 경우 SQL문으로 setp result에 양식에 맞는 {} 데이터 INSERT
- ***

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

step result 트리거가 업데이트 됨에 따라
예기치 못한 오류를 방지하기 위하여
부득이하게 등록하신 주소 일부를 db에서 삭제하였습니다
(삭제 기준 : 등기부등본, 납세증명서가 없는 주소)

계정에 등록된 주소가 일부 사라졌더라도 당황하지 않으시길 바랍니다
감사합니다

- [ ] build 체크 했나요? 제 문제는 아닌 듯 함
<img width="828" height="208" alt="image" src="https://github.com/user-attachments/assets/500ac695-6ff0-4117-b154-1f87336efa7c" />


- [x] dev를 pull 받은 뒤 merge 했나요? 최신 dev에서 분기. 수정 있으면 추가로 merge하겠습니다.