### PR TITLE
fix: hambugi dashboard 결과값 가져오기 개선

### DIFF
--- a/app/(anon)/_components/dashboard/HambugiDashboard.tsx
+++ b/app/(anon)/_components/dashboard/HambugiDashboard.tsx
@@ -10,30 +10,12 @@ import { useGetStepResult } from '@/hooks/useStepResultQueries';
 import DashboardHeader from './DashboardHeader';
 import UserInfo from './UserInfo';
 import StepNavigation from './StepNavigation';
-import StepDetailContent from './StepDetailContent';
+import StepDetailContent, { GuideStepData } from './StepDetailContent';
 import LoadingOverlay from '@/(anon)/_components/common/loading/LoadingOverlay';
 import { styles } from './HambugiDashboard.styles';
 import { STEP_TITLES } from '@libs/constants/stepDetailTitles';
 
-interface StepDetail {
-  id: string;
-  title: string;
-  content: string;
-  status: 'match' | 'mismatch' | 'unchecked';
-  actionLink?: string;
-  actionText?: string;
-}
 
-interface StepResultItem {
-  id: number;
-  userAddressId: number;
-  stepId: number;
-  stepNumber: number;
-  mismatch: number;
-  match: number;
-  unchecked: number;
-  detail: number;
-}
 
 interface HambugiDashboardProps {
   onClose: () => void;
@@ -59,7 +41,7 @@ export default function HambugiDashboard({ onClose }: HambugiDashboardProps) {
   });
   
   // guideSteps 데이터 처리 - data가 배열인 경우 그대로 사용, 객체인 경우 results 배열 추출
-  const guideSteps = Array.isArray(stepResultsData) ? stepResultsData : 
+  const guideSteps: GuideStepData[] = Array.isArray(stepResultsData) ? stepResultsData : 
     (stepResultsData && typeof stepResultsData === 'object' && 'results' in stepResultsData && Array.isArray(stepResultsData.results) ? stepResultsData.results : []);
   console.log('guideSteps', guideSteps);
   // currentStep에 따라 isActive 동적 설정
@@ -111,37 +93,7 @@ export default function HambugiDashboard({ onClose }: HambugiDashboardProps) {
     [currentStep]
   );
 
-  // 실제 데이터를 기반으로 stepDetails 동적 생성
-  const stepDetails = useMemo(() => {
-    if (!guideSteps || guideSteps.length === 0) {
-      return {};
-    }
 
-    const details: Record<number, { title: string; details: StepDetail[] }> = {};
-
-    // 각 스텝별로 데이터 그룹화
-    guideSteps.forEach((step: StepResultItem) => {
-      const stepNumber = step.stepNumber;
-      if (!details[stepNumber]) {
-        details[stepNumber] = {
-          title: `${stepNumber}단계`,
-          details: []
-        };
-      }
-
-      // 각 detail에 대한 정보 생성
-      const detail: StepDetail = {
-        id: `${stepNumber}-${step.detail}`,
-        title: `Detail ${step.detail}`,
-        content: `Match: ${step.match}, Mismatch: ${step.mismatch}, Unchecked: ${step.unchecked}`,
-        status: step.match > 0 ? 'match' : step.mismatch > 0 ? 'mismatch' : 'unchecked'
-      };
-
-      details[stepNumber].details.push(detail);
-    });
-
-    return details;
-  }, [guideSteps]);
 
   // 로딩 상태 처리
   if (isLoading) {
@@ -224,11 +176,6 @@ export default function HambugiDashboard({ onClose }: HambugiDashboardProps) {
     // 액션 링크 처리
   };
 
-  const currentStepData = stepDetails[currentStep] || {
-    title: '단계 정보 없음',
-    details: [],
-  };
-
   return (
     <div className={styles.container}>
       {/* 헤더 */}
@@ -257,8 +204,8 @@ export default function HambugiDashboard({ onClose }: HambugiDashboardProps) {
         {/* 오른쪽: 단계 상세 내용 */}
         <div className={styles.rightPanel}>
           <StepDetailContent
-            stepTitle={currentStepData.title}
-            details={currentStepData.details}
+            stepTitle={STEP_TITLES[currentStep - 1] || '단계 정보'}
+            guideSteps={guideSteps}
             onActionClick={handleActionClick}
             currentStep={currentStep}
           />

--- a/app/(anon)/_components/dashboard/StepDetailContent.tsx
+++ b/app/(anon)/_components/dashboard/StepDetailContent.tsx
@@ -8,53 +8,76 @@ import GuideStepRow from '@/(anon)/_components/common/guideStepContent/GuideStep
 import GuideStepText from '@/(anon)/_components/common/guideStepContent/GuideStepText';
 import { STEP_DETAIL_TITLES } from '@libs/constants/stepDetailTitles';
 
-interface StepDetail {
-  id: string;
-  title: string;
-  content: string;
-  status: 'match' | 'mismatch' | 'unchecked';
-  actionLink?: string;
-  actionText?: string;
-  stepNumber?: number;
-  detail?: number;
+// GuideResultView와 동일한 인터페이스 사용
+export interface GuideStepData {
+  id: number;
+  userAddressId: number;
+  stepId: number;
+  mismatch: number;
+  match: number;
+  unchecked: number;
+  createdAt: string;
+  updatedAt: string;
+  stepNumber: number;
+  detail: number;
+  expanded?: boolean;
+
+  // Fields for GuideStepItem and its content, primarily for stepNumber 1
+  title?: string;
+  content?: string;
+  type?: 'match' | 'mismatch' | 'unchecked' | 'link';
+  multiLine?: boolean;
+  hasLink?: boolean;
+  linkHref?: string;
+  linkText?: string;
+
+  // The 'details' field from API can be either an object or an array of strings
+  details?: {
+    checkItems?: string[];
+    [key: string]: string | string[] | undefined;
+  } | string[];
 }
 
 interface StepDetailContentProps {
   stepTitle: string;
-  details: StepDetail[];
+  guideSteps: GuideStepData[];
   onActionClick: (actionLink: string) => void;
   currentStep?: number;
 }
 
-export default function StepDetailContent({ details, onActionClick, currentStep = 1 }: StepDetailContentProps) {
+export default function StepDetailContent({ guideSteps, onActionClick, currentStep = 1 }: StepDetailContentProps) {
+  // currentStep에 해당하는 스텝들만 필터링
+  const currentStepData = guideSteps.filter(step => step.stepNumber === currentStep);
+  
+  // detail 번호 순으로 정렬
+  const sortedStepData = currentStepData.sort((a, b) => a.detail - b.detail);
+
   return (
     <div className={styles.container}>      
-      {details.map((detail, index) => (
+      {sortedStepData.map((step, index) => (
         <GuideStepItem 
-          key={detail.id}
-          stepNumber={`${currentStep}-${index + 1}`}
-          title={STEP_DETAIL_TITLES[currentStep]?.[index] || detail.title}
-          showDivider={index < details.length - 1}
+          key={step.id}
+          stepNumber={`${step.stepNumber}-${step.detail}`}
+          title={STEP_DETAIL_TITLES[step.stepNumber]?.[step.detail - 1] || `${step.stepNumber}단계 서브 ${step.detail}`}
+          showDivider={index < sortedStepData.length - 1}
         >
           <GuideStepContent>
-
-            
-            {/* 통계 정보 표시 (마이페이지와 동일한 스타일) */}
+            {/* 통계 정보 표시 (GuideResultView와 동일한 스타일) */}
             <GuideStepRow iconType="match">
               <GuideStepText>
-                안전: {detail.status === 'match' ? '1' : '0'}개
+                안전: {step.match}개
               </GuideStepText>
             </GuideStepRow>
             
             <GuideStepRow iconType="mismatch">
               <GuideStepText>
-                경고: {detail.status === 'mismatch' ? '1' : '0'}개
+                경고: {step.mismatch}개
               </GuideStepText>
             </GuideStepRow>
             
             <GuideStepRow iconType="unchecked">
               <GuideStepText>
-                미확인: {detail.status === 'unchecked' ? '1' : '0'}개
+                미확인: {step.unchecked}개
               </GuideStepText>
             </GuideStepRow>
           </GuideStepContent>

--- a/app/(anon)/mypage/_components/GuideResultView.tsx
+++ b/app/(anon)/mypage/_components/GuideResultView.tsx
@@ -103,6 +103,9 @@ export default function GuideResultView({ guideSteps }: GuideResultViewProps) {
           const totalUnchecked = steps.reduce((sum, step) => sum + step.unchecked, 0);
           const isExpanded = steps.some(step => step.expanded);
 
+          // detail 번호 순으로 정렬
+          const sortedSteps = steps.sort((a, b) => a.detail - b.detail);
+
           return (
             <ResultAccordion
               key={stepNumber}
@@ -114,8 +117,8 @@ export default function GuideResultView({ guideSteps }: GuideResultViewProps) {
               <div className={styles.stepContent}>
                 {/* 모든 단계를 1단계처럼 통일하여 깔끔하게 표시 */}
                 <div>
-                  {steps.map((subStep) => (
-                                         <GuideStepItem
+                  {sortedSteps.map((subStep) => (
+                      <GuideStepItem
                        key={subStep.id}
                        stepNumber={`${subStep.stepNumber}-${subStep.detail}`}
                        title={STEP_DETAIL_TITLES[subStep.stepNumber]?.[subStep.detail - 1] || `${STEP_TITLES[stepIndex]} 서브 ${subStep.detail}`}

--- a/app/(anon)/mypage/_components/ResultAccordion.styles.ts
+++ b/app/(anon)/mypage/_components/ResultAccordion.styles.ts
@@ -26,6 +26,6 @@ export const styles = {
   // 아코디언 내용 영역
   content: "bg-brand-light-gray/20 border-t border-brand-light-gray/20 overflow-hidden transition-all duration-300 ease-in-out",
   contentClosed: "max-h-0 py-0 px-0 opacity-0 border-t-0",
-  contentOpen: "max-h-[1000px] py-4 px-4 opacity-100",
+  contentOpen: "py-4 px-4 opacity-100",
   bottomBorder: "border-b border-brand-light-gray"
 } as const;

--- a/app/(anon)/mypage/_components/ResultAccordion.tsx
+++ b/app/(anon)/mypage/_components/ResultAccordion.tsx
@@ -71,6 +71,9 @@ const ResultAccordion = ({
           styles.content,
           isOpen ? styles.contentOpen : styles.contentClosed
         )}
+        style={{
+          maxHeight: isOpen ? 'none' : '0px'
+        }}
       >
         {children}
       </div>


### PR DESCRIPTION
- result 컴포넌트 내에서 데이터 요청하여 처리

## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #325 

---

## 🛠 작업 내용
<img width="408" height="460" alt="image" src="https://github.com/user-attachments/assets/0e0b0ef6-27fa-4e8f-9f9e-3ff9e5ea8b27" />

<img width="489" height="702" alt="image" src="https://github.com/user-attachments/assets/10ef5641-e9f6-44f4-ab22-838c7a6de81e" />


- 햄부기 대시보드에 result 결과값 연결 (컴포넌트 내에서 요청하도록 수정)
- 마이페이지 결과가 1-6까지 나오지 않는 문제 : 이전에 등록했던 주소라서 1-5, 1-6 결과값이 없어 생긴 문제. 이후 저장한 주소에 대해서는 잘 나옴.
- 마이페이지 아코디언 결과가 잘리던 문제 : 최대 높이 지워서 해결
- ***

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] build 체크 했나요? (any 오류 타 브랜치에서 해결됨)

- [x] dev를 pull 받은 뒤 merge 했나요? (최신 dev분기)